### PR TITLE
Fixed readme on getting regular JSON schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ schema.validate({
 
 ### Getting a standard jsonSchema
 ```javascript
-schema.toJsonSchema();
+schema.getJsonSchema();
 ```
 
 returns:


### PR DESCRIPTION
The readme mentions a method `toJsonSchema`, but in the code it's actually `getJsonSchema`
